### PR TITLE
Sep 2020 updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ futures = "0.1"
 galvanic-test = "0.1.5"
 getopts = "0.2"
 sysctl = "0.1"
-tempdir = "0.3"
+tempfile = "3.0"
 tokio = "0.1.6"
 
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "https://asomers.github.io/tokio-file/tokio_file/"
 [dependencies]
 futures = "0.1.10"
 mio = "0.6.13"
-nix = "0.*.1, >= 0.12.1"
+nix = "0.18.0"
 mio-aio = "0.4.1"
 tokio-reactor = "0.1.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio-reactor = "0.1.6"
 [dev-dependencies]
 divbuf = "0.3.1"
 futures = "0.1"
-galvanic-test = "0.1.5"
+galvanic-test = "0.2.0"
 getopts = "0.2"
 sysctl = "0.1"
 tempfile = "3.0"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,7 +2,7 @@
 
 extern crate divbuf;
 extern crate futures;
-extern crate tempdir;
+extern crate tempfile;
 extern crate tokio;
 extern crate tokio_file;
 extern crate test;
@@ -14,7 +14,7 @@ use std::io::Write;
 use std::os::unix::fs::FileExt;
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
-use tempdir::TempDir;
+use tempfile::TempDir;
 use test::Bencher;
 use tokio::runtime::current_thread::Runtime;
 use tokio_file::File;
@@ -24,7 +24,7 @@ const FLEN: usize = 1<<19;
 #[bench]
 fn bench_aio_read(bench: &mut Bencher) {
     // First prep the test file
-    let dir = TempDir::new("tokio-file").unwrap();
+    let dir = TempDir::new().unwrap();
     let path = dir.path().join("aio_read");
     let mut f = fs::File::create(&path).unwrap();
     let wbuf = vec![0; FLEN];
@@ -51,7 +51,7 @@ fn bench_aio_read(bench: &mut Bencher) {
 #[bench]
 fn bench_threaded_read(bench: &mut Bencher) {
     // First prep the test file
-    let dir = TempDir::new("tokio-file").unwrap();
+    let dir = TempDir::new().unwrap();
     let path = dir.path().join("threaded_read");
     let mut f = fs::File::create(&path).unwrap();
     let wbuf = vec![0; FLEN];
@@ -91,7 +91,7 @@ struct TpOpspec {
 #[bench]
 fn bench_threadpool_read(bench: &mut Bencher) {
     // First prep the test file
-    let dir = TempDir::new("tokio-file").unwrap();
+    let dir = TempDir::new().unwrap();
     let path = dir.path().join("threadpool_read");
     let mut f = fs::File::create(&path).unwrap();
     let wbuf = vec![0; FLEN];

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,10 +1,5 @@
 #![feature(test)]
 
-extern crate divbuf;
-extern crate futures;
-extern crate tempfile;
-extern crate tokio;
-extern crate tokio_file;
 extern crate test;
 
 use divbuf::{DivBufMut, DivBufShared};

--- a/examples/dd.rs
+++ b/examples/dd.rs
@@ -7,12 +7,6 @@
 //!     cargo run --example dd -- -b 4096 -c 100 /tmp/infile /tmp/outfile
 //!     cmp /tmp/infile /tmp/outfile
 
-extern crate divbuf;
-extern crate futures;
-extern crate getopts;
-extern crate tokio;
-extern crate tokio_file;
-
 use divbuf::DivBufShared;
 use futures::future::Future;
 use futures::future::lazy;

--- a/src/file.rs
+++ b/src/file.rs
@@ -317,13 +317,13 @@ impl File {
     /// use std::borrow::BorrowMut;
     /// use std::fs;
     /// use std::io::Write;
-    /// use tempdir::TempDir;
+    /// use tempfile::TempDir;
     /// use tokio::runtime::current_thread;
     ///
     /// const WBUF: &[u8] = b"abcdef";
     /// const EXPECT: &[u8] = b"cdef";
     /// let rbuf = Box::new(vec![0; 4].into_boxed_slice());
-    /// let dir = TempDir::new("tokio-file").unwrap();
+    /// let dir = TempDir::new().unwrap();
     /// let path = dir.path().join("foo");
     /// let mut f = fs::File::create(&path).unwrap();
     /// f.write(WBUF).unwrap();
@@ -386,7 +386,7 @@ impl File {
     /// use std::borrow::BorrowMut;
     /// use std::fs;
     /// use std::io::Write;
-    /// use tempdir::TempDir;
+    /// use tempfile::TempDir;
     /// use tokio::runtime::current_thread;
     ///
     /// const WBUF: &[u8] = b"abcdefghijklmnopqrwtuvwxyz";
@@ -396,7 +396,7 @@ impl File {
     /// let rbuf1 = Box::new(vec![0; 8].into_boxed_slice());
     /// let rbufs : Vec<Box<dyn BorrowMut<[u8]>>> = vec![rbuf0, rbuf1];
     ///
-    /// let dir = TempDir::new("tokio-file").unwrap();
+    /// let dir = TempDir::new().unwrap();
     /// let path = dir.path().join("foo");
     /// let mut f = fs::File::create(&path).unwrap();
     /// f.write(WBUF).unwrap();
@@ -496,14 +496,14 @@ impl File {
     /// use std::borrow::Borrow;
     /// use std::fs;
     /// use std::io::Read;
-    /// use tempdir::TempDir;
+    /// use tempfile::TempDir;
     /// use tokio::runtime::current_thread;
     ///
     /// let contents = b"abcdef";
     /// let wbuf: Box<dyn Borrow<[u8]>> = Box::new(&contents[..]);
     /// let mut rbuf = Vec::new();
     ///
-    /// let dir = TempDir::new("tokio-file").unwrap();
+    /// let dir = TempDir::new().unwrap();
     /// let path = dir.path().join("foo");
     /// let file = fs::OpenOptions::new()
     ///     .create(true)
@@ -562,7 +562,7 @@ impl File {
     /// use std::borrow::Borrow;
     /// use std::fs;
     /// use std::io::Read;
-    /// use tempdir::TempDir;
+    /// use tempfile::TempDir;
     /// use tokio::runtime::current_thread;
     ///
     /// const EXPECT: &[u8] = b"abcdefghij";
@@ -571,7 +571,7 @@ impl File {
     /// let wbufs : Vec<Box<dyn Borrow<[u8]>>> = vec![wbuf0, wbuf1];
     /// let mut rbuf = Vec::new();
     ///
-    /// let dir = TempDir::new("tokio-file").unwrap();
+    /// let dir = TempDir::new().unwrap();
     /// let path = dir.path().join("foo");
     /// let file = fs::OpenOptions::new()
     ///     .create(true)
@@ -674,10 +674,10 @@ impl File {
     /// use std::borrow::BorrowMut;
     /// use std::fs;
     /// use std::io::Write;
-    /// use tempdir::TempDir;
+    /// use tempfile::TempDir;
     /// use tokio::runtime::current_thread;
     ///
-    /// let dir = TempDir::new("tokio-file").unwrap();
+    /// let dir = TempDir::new().unwrap();
     /// let path = dir.path().join("foo");
     ///
     /// let file = fs::OpenOptions::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,14 @@
 //! use std::borrow::Borrow;
 //! use std::fs;
 //! use std::io::Read;
-//! use tempdir::TempDir;
+//! use tempfile::TempDir;
 //! use tokio::runtime::current_thread;
 //!
 //! let contents = b"abcdef";
 //! let wbuf: Box<Borrow<[u8]>> = Box::new(&contents[..]);
 //! let mut rbuf = Vec::new();
 //!
-//! let dir = TempDir::new("tokio-file").unwrap();
+//! let dir = TempDir::new().unwrap();
 //! let path = dir.path().join("foo");
 //! let file = fs::OpenOptions::new()
 //!     .create(true)

--- a/tests/aio_write_eagain.rs
+++ b/tests/aio_write_eagain.rs
@@ -2,14 +2,14 @@ extern crate divbuf;
 extern crate futures;
 extern crate nix;
 extern crate sysctl;
-extern crate tempdir;
+extern crate tempfile;
 extern crate tokio;
 extern crate tokio_file;
 
 use divbuf::DivBufShared;
 use futures::future::lazy;
 use futures::{Future, future};
-use tempdir::TempDir;
+use tempfile::TempDir;
 use tokio_file::{AioResult, File};
 use tokio::runtime::current_thread;
 
@@ -31,7 +31,7 @@ fn write_at_eagain() {
         panic!("sysctl: {:?}", limit);
     };
 
-    let dir = t!(TempDir::new("tokio-file"));
+    let dir = t!(TempDir::new());
     let path = dir.path().join("write_at_eagain.0");
     let file = t!(File::open(&path));
 

--- a/tests/aio_write_eagain.rs
+++ b/tests/aio_write_eagain.rs
@@ -1,11 +1,3 @@
-extern crate divbuf;
-extern crate futures;
-extern crate nix;
-extern crate sysctl;
-extern crate tempfile;
-extern crate tokio;
-extern crate tokio_file;
-
 use divbuf::DivBufShared;
 use futures::future::lazy;
 use futures::{Future, future};

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -2,7 +2,7 @@ extern crate divbuf;
 #[macro_use] extern crate galvanic_test;
 extern crate nix;
 extern crate futures;
-extern crate tempdir;
+extern crate tempfile;
 extern crate tokio;
 extern crate tokio_file;
 
@@ -15,7 +15,7 @@ use std::fs;
 use std::io::{Read, Write};
 use std::path::Path;
 use std::process::Command;
-use tempdir::TempDir;
+use tempfile::TempDir;
 use tokio_file::File;
 use tokio::runtime::current_thread;
 
@@ -29,7 +29,7 @@ macro_rules! t {
 #[test]
 fn metadata() {
     let wbuf = vec![0; 9000].into_boxed_slice();
-    let dir = t!(TempDir::new("tokio-file"));
+    let dir = t!(TempDir::new());
     let path = dir.path().join("read_at");
     let mut f = t!(fs::File::create(&path));
     f.write_all(&wbuf).expect("write failed");
@@ -40,7 +40,7 @@ fn metadata() {
 
 #[test]
 fn len() {
-    let dir = t!(TempDir::new("tokio-file"));
+    let dir = t!(TempDir::new());
     let path = dir.path().join("read_at");
     let f = t!(fs::File::create(&path));
     f.set_len(9000).unwrap();
@@ -53,7 +53,7 @@ fn len() {
 /// specified.
 #[test]
 fn new_nocreat() {
-    let dir = t!(TempDir::new("tokio-file"));
+    let dir = t!(TempDir::new());
     let path = dir.path().join("nonexistent");
     let r = fs::OpenOptions::new()
         .read(true)
@@ -72,7 +72,7 @@ fn read_at() {
     let rbuf = Box::new(dbs.try_mut().unwrap());
     let off = 2;
 
-    let dir = t!(TempDir::new("tokio-file"));
+    let dir = t!(TempDir::new());
     let path = dir.path().join("read_at_divbuf_mut");
     let mut f = t!(fs::File::create(&path));
     f.write_all(WBUF).expect("write failed");
@@ -101,7 +101,7 @@ fn readv_at() {
     let rbufs : Vec<Box<dyn BorrowMut<[u8]>>> = vec![rbuf0, rbuf1];
     let off = 2;
 
-    let dir = t!(TempDir::new("tokio-file"));
+    let dir = t!(TempDir::new());
     let path = dir.path().join("readv_at");
     let mut f = t!(fs::File::create(&path));
     f.write_all(WBUF).expect("write failed");
@@ -128,7 +128,7 @@ fn readv_at() {
 fn sync_all() {
     const WBUF: &[u8] = b"abcdef";
 
-    let dir = t!(TempDir::new("tokio-file"));
+    let dir = t!(TempDir::new());
     let path = dir.path().join("sync_all");
     let mut f = t!(fs::File::create(&path));
     f.write_all(WBUF).expect("write failed");
@@ -146,7 +146,7 @@ fn write_at() {
     let wbuf = Box::new(dbs.try_const().unwrap());
     let mut rbuf = Vec::new();
 
-    let dir = t!(TempDir::new("tokio-file"));
+    let dir = t!(TempDir::new());
     let path = dir.path().join("write_at");
     let file = t!(File::open(&path));
     let mut rt = current_thread::Runtime::new().unwrap();
@@ -171,7 +171,7 @@ fn writev_at() {
     let wbufs : Vec<Box<dyn Borrow<[u8]>>> = vec![wbuf0, wbuf1];
     let mut rbuf = Vec::new();
 
-    let dir = t!(TempDir::new("tokio-file"));
+    let dir = t!(TempDir::new());
     let path = dir.path().join("writev_at");
     let file = t!(File::open(&path));
     let mut rt = current_thread::Runtime::new().unwrap();
@@ -203,7 +203,7 @@ fn write_at_static() {
     let wbuf = Box::new(WBUF);
     let mut rbuf = Vec::new();
 
-    let dir = t!(TempDir::new("tokio-file"));
+    let dir = t!(TempDir::new());
     let path = dir.path().join("write_at");
     {
         let file = t!(File::open(&path));
@@ -230,7 +230,7 @@ fn writev_at_static() {
     let wbufs : Vec<Box<dyn Borrow<[u8]>>> = vec![wbuf0, wbuf1];
     let mut rbuf = Vec::new();
 
-    let dir = t!(TempDir::new("tokio-file"));
+    let dir = t!(TempDir::new());
     let path = dir.path().join("writev_at_static");
     let file = t!(File::open(&path));
     let mut rt = current_thread::Runtime::new().unwrap();

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -1,13 +1,6 @@
-extern crate divbuf;
-#[macro_use] extern crate galvanic_test;
-extern crate nix;
-extern crate futures;
-extern crate tempfile;
-extern crate tokio;
-extern crate tokio_file;
-
 use divbuf::DivBufShared;
 use futures::future::lazy;
+use galvanic_test::*;
 use nix::unistd::Uid;
 use std::borrow::{Borrow, BorrowMut};
 use std::ffi::OsStr;

--- a/tests/lio_listio_incomplete.rs
+++ b/tests/lio_listio_incomplete.rs
@@ -1,11 +1,3 @@
-extern crate divbuf;
-extern crate futures;
-extern crate nix;
-extern crate sysctl;
-extern crate tempfile;
-extern crate tokio;
-extern crate tokio_file;
-
 use divbuf::DivBufShared;
 use futures::future;
 use nix::unistd::{SysconfVar, sysconf};

--- a/tests/lio_listio_incomplete.rs
+++ b/tests/lio_listio_incomplete.rs
@@ -2,7 +2,7 @@ extern crate divbuf;
 extern crate futures;
 extern crate nix;
 extern crate sysctl;
-extern crate tempdir;
+extern crate tempfile;
 extern crate tokio;
 extern crate tokio_file;
 
@@ -11,7 +11,7 @@ use futures::future;
 use nix::unistd::{SysconfVar, sysconf};
 use std::borrow::Borrow;
 use sysctl::CtlValue;
-use tempdir::TempDir;
+use tempfile::TempDir;
 use tokio_file::File;
 use tokio::runtime::current_thread;
 
@@ -53,7 +53,7 @@ fn writev_at_eio() {
         panic!("Can't find a configuration for max_aio_queue_per_proc={} AIO_LISTIO_MAX={}", maqpp, alm);
     }
 
-    let dir = t!(TempDir::new("tokio-file"));
+    let dir = t!(TempDir::new());
     let path = dir.path().join("writev_at_eio");
     let file = t!(File::open(&path));
     let dbses: Vec<_> = (0..num_listios).map(|_| {


### PR DESCRIPTION
    Update nix to 0.18.0
    
    tokio-file itself does not need this update, but all consumers of nix in
    an application must be using the same version.

    Switch from the tempdir crate to tempfile

    Remove "extern crate"
    
    It isn't needed in edition 2018