### PR TITLE
Handle errors from PollEvented::poll_read_ready

### DIFF
--- a/examples/dd.rs
+++ b/examples/dd.rs
@@ -40,7 +40,7 @@ impl Dd {
 
 fn usage(opts: Options) {
     let brief = "Usage: dd [options] <INFILE> <OUTFILE>";
-    print!("{}", opts.usage(&brief));
+    print!("{}", opts.usage(brief));
 }
 
 


### PR DESCRIPTION
tokio-file was ignoring these errors.  I'm not sure when Tokio will ever
return an error here, but now tokio-file will no longer ignore it.