### PR TITLE
Fix lio_listio resubmission with Tokio 1.13.0 and later

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ futures = "0.3.0"
 mio = "0.7.7"
 nix = "0.22.0"
 mio-aio = { version = "0.6.0", features = ["tokio"] }
-tokio = { git = "https://github.com/tokio-rs/tokio", rev = "957ed3e", features = [ "net" ] }
+tokio = { version = "1.12.0", features = [ "net" ] }
 
 [dev-dependencies]
 rstest = "0.11.0"
 getopts = "0.2.18"
 sysctl = "0.1"
 tempfile = "3.0"
-tokio = { git = "https://github.com/tokio-rs/tokio", rev = "957ed3e", features = [ "net", "rt" ] }
+tokio = { version = "1.12.0", features = [ "net", "rt" ] }
 
 [[test]]
 name = "functional"

--- a/tests/lio_listio_incomplete.rs
+++ b/tests/lio_listio_incomplete.rs
@@ -15,7 +15,7 @@ macro_rules! t {
 // A writev_at call fails because lio_listio(2) returns EIO.  That means that
 // some of the AioCbs may have been initiated, but not all.
 // This test must run in its own process since it intentionally uses all of the
-// system's AIO resources.
+// process's AIO resources.
 #[test]
 fn writev_at_eio() {
     let alm = sysconf(SysconfVar::AIO_LISTIO_MAX).expect("sysconf").unwrap();


### PR DESCRIPTION
According to @darksonn there have never been a guarantee that a future
will get poll()'d a second time if you do not call poll_ready() a second
time after it previously returned Poll::Ready.  But due to a bug in
Tokio 1.12.0 and earlier we got away with it.  Fix it the right way, and
update the Tokio dependency now that the PollAio stuff is merged.

Fixes #27