### PR TITLE
Add a benchmark based on Tokio's AsyncReadExt trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ getopts = "0.2.18"
 nix = { version = "0.24.0", default-features = false, features = ["ioctl", "feature", "user"] }
 sysctl = "0.1"
 tempfile = "3.0"
-tokio = { version = "1.17.0", features = [ "net", "rt" ] }
+tokio = { version = "1.17.0", features = [ "fs", "io-util", "net", "rt" ] }
 
 [[test]]
 name = "functional"


### PR DESCRIPTION
This trait uses threaded I/O under the hood.  It currently runs about
12x slower than tokio-file's AIO-based reads.