### PR TITLE
The error type of all futures is now io::Result.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   matching changes in its dependencies.
   (#[34](https://github.com/asomers/tokio-file/pull/34))
 
+- The error type of all futures is now `io::Result`.  This should make
+  consumers' builds less dependent on the precise version of Nix in use.
+  (#[39](https://github.com/asomers/tokio-file/pull/39))
+
 - Updated Nix to 0.26.1.  This also raises MSRV to 1.56.1.
   (#[37](https://github.com/asomers/tokio-file/pull/37))
 

--- a/tests/aio_write_eagain.rs
+++ b/tests/aio_write_eagain.rs
@@ -1,3 +1,4 @@
+use std::io::ErrorKind;
 use futures::future;
 use tempfile::TempDir;
 use tokio_file::File;
@@ -47,7 +48,7 @@ fn write_at_eagain() {
                 n_ok += 1;
                 assert_eq!(aio_result, 4096);
             },
-            Err(nix::errno::Errno::EAGAIN) => n_eagain += 1,
+            Err(e) if e.kind() == ErrorKind::WouldBlock => n_eagain += 1,
             Err(e) => panic!("unexpected result {:?}", e)
         }
     }


### PR DESCRIPTION
This should make consumers' builds less dependent on the precise version of Nix in use.