### PR TITLE
Update rstest to 0.16.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,7 @@ setup: &SETUP
 task:
   name: FreeBSD 13.1 MSRV
   env:
-    VERSION: 1.58.0
+    VERSION: 1.61.0
   << : *SETUP
   test_script:
     - . $HOME/.cargo/env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@
 - Updated Nix to 0.26.1.
   (#[38](https://github.com/asomers/tokio-file/pull/38))
 
-- Raised MSRV to 1.58.0
-  (#[40](https://github.com/asomers/tokio-file/pull/40))
+- Raised MSRV to 1.61.0
+  (#[41](https://github.com/asomers/tokio-file/pull/41))
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ mio-aio = { git = "http://github.com/asomers/mio-aio", rev = "69974fb", features
 tokio = { version = "1.17.0", features = [ "net" ] }
 
 [dev-dependencies]
-rstest = "0.11.0"
+rstest = "0.16.0"
 getopts = "0.2.18"
 nix = { version = "0.26.1", default-features = false, features = ["aio", "feature", "ioctl", "user"] }
 sysctl = "0.1"


### PR DESCRIPTION
Because older versions using deprecated
semicolon-in-expression-position syntax.