### PR TITLE
Eliminate vulnerability in the remove_dir_all crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rstest = "0.16.0"
 getopts = "0.2.18"
 nix = { version = "0.26.1", default-features = false, features = ["aio", "feature", "ioctl", "user"] }
 sysctl = "0.1"
-tempfile = "3.0"
+tempfile = "3.4"
 tokio = { version = "1.17.0", features = [ "fs", "io-util", "net", "rt" ] }
 
 [[test]]


### PR DESCRIPTION
It was transitively pulled in by tempfile.  This change should not affect regular users of tokio-file, just developers.