### PR TITLE
Use EV_ONESHOT.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,7 @@ setup: &SETUP
 task:
   name: FreeBSD 13.2 MSRV
   env:
-    VERSION: 1.63.0
+    VERSION: 1.65.0
   << : *SETUP
   test_script:
     - . $HOME/.cargo/env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 - Raised MSRV to 1.63.0
   (#[41](https://github.com/asomers/tokio-file/pull/41))
   (#[44](https://github.com/asomers/tokio-file/pull/44))
+  (#[45](https://github.com/asomers/tokio-file/pull/45))
+
+- Update Nix and mio-aio dependencies.  See mio-aio (#[38](https://github.com/asomers/mio-aio/pull/38 for motivation.)).
+  (#[45](https://github.com/asomers/tokio-file/pull/45))
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,17 +20,17 @@ targets = [
 [dependencies]
 futures = "0.3.0"
 mio = "0.8.1"
-nix = { version = "0.26.1", default-features = false, features = ["aio", "ioctl"] }
-mio-aio = { git = "http://github.com/asomers/mio-aio", rev = "69974fb", features = ["tokio"] }
+nix = {version = "0.27.0", default-features = false, features = ["ioctl"] }
+mio-aio = { version = "0.8.0", features = ["tokio"] }
 tokio = { version = "1.17.0", features = [ "net" ] }
 
 [dev-dependencies]
 rstest = "0.16.0"
 getopts = "0.2.18"
-nix = { version = "0.26.1", default-features = false, features = ["aio", "feature", "ioctl", "user"] }
+nix = {version = "0.27.0", default-features = false, features = ["user"] }
 sysctl = "0.1"
 tempfile = "3.4"
-tokio = { version = "1.17.0", features = [ "fs", "io-util", "net", "rt" ] }
+tokio = { version = "1.17.0", features = [ "fs", "io-util", "net", "rt", "rt-multi-thread" ] }
 
 [[test]]
 name = "functional"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -16,7 +16,7 @@ use tokio_file::File;
 const FLEN: usize = 1<<19;
 
 fn runtime() -> Runtime {
-    runtime::Builder::new_current_thread()
+    runtime::Builder::new_multi_thread()
         .enable_io()
         .build()
         .unwrap()
@@ -36,13 +36,13 @@ fn bench_aio_read(bench: &mut Bencher) {
     let file = File::open(path).unwrap();
 
     let mut rbuf = vec![0u8; FLEN];
-    bench.iter(move || {
+    bench.iter(|| {
         let len = runtime.block_on(async{
             file.read_at(&mut rbuf[..], 0)
                 .expect("read_at failed early").await
         }).unwrap();
         assert_eq!(len, wbuf.len());
-    })
+    });
 }
 
 // For comparison, benchmark the equivalent operation using threads


### PR DESCRIPTION
So tokio-file can be used by a multithreaded tokio runtime.

See also https://github.com/tokio-rs/tokio/issues/4728