### PR TITLE
Raise the tokio dependency to 1.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3.0"
 mio = "0.8.1"
 nix = {version = "0.27.0", default-features = false, features = ["ioctl"] }
 mio-aio = { version = "0.8.0", features = ["tokio"] }
-tokio = { version = "1.17.0", features = [ "net" ] }
+tokio = { version = "1.19.0", features = [ "net" ] }
 
 [dev-dependencies]
 rstest = "0.16.0"
@@ -30,7 +30,7 @@ getopts = "0.2.18"
 nix = {version = "0.27.0", default-features = false, features = ["user"] }
 sysctl = "0.1"
 tempfile = "3.4"
-tokio = { version = "1.17.0", features = [ "fs", "io-util", "net", "rt", "rt-multi-thread" ] }
+tokio = { version = "1.19.0", features = [ "fs", "io-util", "net", "rt", "rt-multi-thread" ] }
 
 [[test]]
 name = "functional"


### PR DESCRIPTION
Fixes RUSTSEC-2023-0001