### PR TITLE
Raise MSRV in tests to 1.66.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,7 @@ setup: &SETUP
 task:
   name: FreeBSD 13.2 MSRV
   env:
-    VERSION: 1.65.0
+    VERSION: 1.66.0
   << : *SETUP
   test_script:
     - . $HOME/.cargo/env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased] - ReleaseDate
+
+### Changed
+
+- Raised MSRV to 1.66.0.
+  (#[48](https://github.com/asomers/tokio-file/pull/48))
+
+
 ## [0.9.0] - 2023-08-29
 
 ### Changed


### PR DESCRIPTION
Because relative-path did.  That crate is only used in tests, but it's too much trouble to lock it to a lower version just for CI.