### PR TITLE
Use I/O safety

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,7 +58,7 @@ task:
   # Test our minimal version spec
   minver_test_script:
     - . $HOME/.cargo/env
-    - cargo +$VERSION update -Zminimal-versions
+    - cargo +$VERSION update -Zdirect-minimal-versions
     - cargo +$VERSION check --all-targets
     - cargo +$VERSION doc --no-deps
   before_cache_script: rm -rf $HOME/.cargo/registry/index

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,7 @@ setup: &SETUP
 task:
   name: FreeBSD 13.3 MSRV
   env:
-    VERSION: 1.66.0
+    VERSION: 1.69.0
   << : *SETUP
   test_script:
     - . $HOME/.cargo/env

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,8 +40,7 @@ task:
 task:
   name: FreeBSD 13.3 nightly
   env:
-    # Workaround Rust bug https://github.com/rust-lang/rust/issues/104815
-    VERSION: nightly-2022-11-19-x86_64-unknown-freebsd
+    VERSION: nightly
   << : *SETUP
   test_script:
     - . $HOME/.cargo/env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Added an extention trait: `AioFileExt`.  It's implemented on everything that
+  implements `AsFd`.  Noteably, these methods use I/O safety, which the old
+  `tokio_file::File` methods did not.
+  (#[53](https://github.com/asomers/tokio-file/pull/53))
+
 ### Changed
 
 - Raised MSRV to 1.66.0.
   (#[48](https://github.com/asomers/tokio-file/pull/48))
 
+### Removed
+
+- Deprecated `File`.  Use the `AioFileExt` trait instead.
 
 ## [0.9.0] - 2023-08-29
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Alan Somers <asomers@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/asomers/tokio-file"
+rust-version = "1.69"
 description = """
 Asynchronous file I/O for Tokio
 """
@@ -20,17 +21,17 @@ targets = [
 [dependencies]
 futures = "0.3.0"
 mio = "0.8.1"
-nix = {version = "0.27.0", default-features = false, features = ["ioctl"] }
-mio-aio = { version = "0.8.0", features = ["tokio"] }
+nix = { version = "0.29.0", default-features = false, features = ["ioctl"] }
+mio-aio = { version = "0.9.0", features = ["tokio"] }
 tokio = { version = "1.19.0", features = [ "net" ] }
 
 [dev-dependencies]
 rstest = "0.18.0"
 getopts = "0.2.18"
-nix = {version = "0.27.0", default-features = false, features = ["user"] }
+nix = {version = "0.29.0", default-features = false, features = ["user"] }
 sysctl = "0.1"
 tempfile = "3.4"
-tokio = { version = "1.19.0", features = [ "fs", "io-util", "net", "macros", "rt", "rt-multi-thread" ] }
+tokio = { version = "1.19.0", features = [ "fs", "io-util", "macros", "net", "rt", "rt-multi-thread" ] }
 tokio-test = "0.4.4"
 
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ targets = [
 ]
 
 [dependencies]
-futures = "0.3.0"
-mio = "0.8.1"
+futures = "0.3.21"
+mio = "0.8.11"
 nix = { version = "0.29.0", default-features = false, features = ["ioctl"] }
 mio-aio = { version = "0.9.0", features = ["tokio"] }
-tokio = { version = "1.19.0", features = [ "net" ] }
+tokio = { version = "1.27.0", features = [ "net" ] }
 
 [dev-dependencies]
 rstest = "0.18.0"
@@ -31,7 +31,7 @@ getopts = "0.2.18"
 nix = {version = "0.29.0", default-features = false, features = ["user"] }
 sysctl = "0.1"
 tempfile = "3.4"
-tokio = { version = "1.19.0", features = [ "fs", "io-util", "macros", "net", "rt", "rt-multi-thread" ] }
+tokio = { version = "1.27.0", features = [ "fs", "io-util", "macros", "net", "rt", "rt-multi-thread" ] }
 tokio-test = "0.4.4"
 
 [[test]]

--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ mixed with all other Future types within the Tokio reactor.
 # Cargo.toml
 [depdendencies]
 tokio = "1.0.0"
-tokio-file = "0.9.0"
+tokio-file = "0.10.0"
 ```
 
 # Usage
 
 See the `examples` directory in the repository.  In general, any program that's
-already using `tokio` can add file I/O by using `tokio_file::File` and
+already using `tokio` can add file I/O by using `tokio_file::AioFileExt` and
 running the resulting futures in the tokio reactor.
 
 # Platforms
 
-`tokio-file` version 0.7 works on FreeBSD, using the `mio-aio` crate.  It will
+`tokio-file` version 0.10 works on FreeBSD, using the `mio-aio` crate.  It will
 probably also work on DragonflyBSD and OSX.  It does not work on Linux.  The
 `tokio-file` API can be supported on Linux, but it will need a completely
 different backend.  Instead of using POSIX AIO as `mio-aio` does, Linux will

--- a/src/file.rs
+++ b/src/file.rs
@@ -3,9 +3,12 @@ use std::{
     fs,
     io::{self, IoSlice, IoSliceMut},
     mem,
-    os::unix::{
-        fs::FileTypeExt,
-        io::{AsRawFd, RawFd}
+    os::{
+        fd::BorrowedFd,
+        unix::{
+            fs::FileTypeExt,
+            io::{AsFd, AsRawFd, RawFd}
+        },
     },
     path::Path,
     pin::Pin
@@ -90,7 +93,7 @@ pub type ReadAt<'a> = TokioFileFut<mio_aio::ReadAt<'a>>;
 pub type ReadvAt<'a> = TokioFileFut<mio_aio::ReadvAt<'a>>;
 
 /// Return type of [`File::sync_all`].  Implements `Future`.
-pub type SyncAll = TokioFileFut<mio_aio::Fsync>;
+pub type SyncAll<'a> = TokioFileFut<mio_aio::Fsync<'a>>;
 
 /// Return type of [`File::write_at`].  Implements `Future`.
 pub type WriteAt<'a> = TokioFileFut<mio_aio::WriteAt<'a>>;
@@ -98,7 +101,249 @@ pub type WriteAt<'a> = TokioFileFut<mio_aio::WriteAt<'a>>;
 /// Return type of [`File::writev_at`].  Implements `Future`.
 pub type WritevAt<'a> = TokioFileFut<mio_aio::WritevAt<'a>>;
 
+/// Adds POSIX AIO-based asynchronous methods to files.
+pub trait AioFileExt: AsFd {
+    /// Asynchronous equivalent of `std::fs::File::read_at`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::fs;
+    /// use std::io::Write;
+    /// use tempfile::TempDir;
+    /// use tokio_file::AioFileExt;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// const WBUF: &[u8] = b"abcdef";
+    /// const EXPECT: &[u8] = b"cdef";
+    /// let mut rbuf = vec![0; 4];
+    /// let dir = TempDir::new().unwrap();
+    /// let path = dir.path().join("foo");
+    /// let mut f = fs::File::create(&path).unwrap();
+    /// f.write(WBUF).unwrap();
+    ///
+    /// let file = fs::OpenOptions::new()
+    ///     .read(true)
+    ///     .open(path)
+    ///     .unwrap();
+    /// let r = file.read_at(&mut rbuf[..], 2).unwrap().await.unwrap();
+    /// assert_eq!(&rbuf[..], &EXPECT[..]);
+    /// # }
+    /// ```
+    fn read_at<'a>(&'a self, buf: &'a mut [u8], offset: u64)
+        -> io::Result<ReadAt<'a>>
+    {
+        let fd = self.as_fd();
+        let source = TokioSource(mio_aio::ReadAt::read_at(fd, offset, buf, 0));
+        Ok(TokioFileFut(Aio::new_for_aio(source)?))
+    }
+
+    /// Asynchronous equivalent of `preadv`.
+    ///
+    /// Similar to
+    /// [preadv(2)](https://www.freebsd.org/cgi/man.cgi?query=read&sektion=2)
+    /// but asynchronous.  Reads a contiguous portion of a file into a
+    /// scatter-gather list of buffers.
+    ///
+    /// # Parameters
+    ///
+    /// - `bufs`:   The destination for the read.  A scatter-gather list of
+    ///             buffers.
+    /// - `offset`: Offset within the file at which to begin the read
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(x)`:  The operation was successfully created.  The future may be
+    ///             polled and will eventually return the final status of the
+    ///             operation.
+    /// - `Err(x)`: An error occurred before issueing the operation.  The result
+    ///             may be `drop`ped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::borrow::BorrowMut;
+    /// use std::fs;
+    /// use std::io::{IoSliceMut, Write};
+    /// use tempfile::TempDir;
+    /// use tokio_file::AioFileExt;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// const WBUF: &[u8] = b"abcdefghijklmnopqrwtuvwxyz";
+    /// const EXPECT0: &[u8] = b"cdef";
+    /// const EXPECT1: &[u8] = b"ghijklmn";
+    /// let l0 = 4;
+    /// let l1 = 8;
+    /// let mut rbuf0 = vec![0; l0];
+    /// let mut rbuf1 = vec![0; l1];
+    /// let mut rbufs = [IoSliceMut::new(&mut rbuf0), IoSliceMut::new(&mut rbuf1)];
+    ///
+    /// let dir = TempDir::new().unwrap();
+    /// let path = dir.path().join("foo");
+    /// let mut f = fs::File::create(&path).unwrap();
+    /// f.write(WBUF).unwrap();
+    ///
+    /// let file = fs::OpenOptions::new()
+    ///     .read(true)
+    ///     .open(path)
+    ///     .unwrap();
+    /// let mut r = file.readv_at(&mut rbufs[..], 2).unwrap().await.unwrap();
+    ///
+    /// assert_eq!(l0 + l1, r);
+    /// assert_eq!(&rbuf0[..], &EXPECT0[..]);
+    /// assert_eq!(&rbuf1[..], &EXPECT1[..]);
+    /// # }
+    /// ```
+    fn readv_at<'a>(&'a self, bufs: &mut [IoSliceMut<'a>],
+                        offset: u64) -> io::Result<ReadvAt<'a>>
+    {
+        let fd = self.as_fd();
+        let source = TokioSource(mio_aio::ReadvAt::readv_at(fd, offset, bufs, 0));
+        Ok(TokioFileFut(Aio::new_for_aio(source)?))
+    }
+
+    /// Asynchronous equivalent of `std::fs::File::sync_all`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::borrow::BorrowMut;
+    /// use std::fs;
+    /// use std::io::Write;
+    /// use tempfile::TempDir;
+    /// use tokio_file::AioFileExt;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let dir = TempDir::new().unwrap();
+    /// let path = dir.path().join("foo");
+    ///
+    /// let file = fs::OpenOptions::new()
+    ///     .write(true)
+    ///     .create(true)
+    ///     .open(path)
+    ///     .unwrap();
+    /// let r = AioFileExt::sync_all(&file).unwrap().await.unwrap();
+    /// # }
+    /// ```
+    // TODO: add sync_all_data, for supported operating systems
+    fn sync_all(&self) -> io::Result<SyncAll> {
+        let mode = AioFsyncMode::O_SYNC;
+        let fd = self.as_fd();
+        let source = TokioSource(mio_aio::Fsync::fsync(fd, mode, 0));
+        Ok(TokioFileFut(Aio::new_for_aio(source)?))
+    }
+
+    /// Asynchronous equivalent of `std::fs::File::write_at`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::fs;
+    /// use std::io::Read;
+    /// use tempfile::TempDir;
+    /// use tokio_file::AioFileExt;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let contents = b"abcdef";
+    /// let mut rbuf = Vec::new();
+    ///
+    /// let dir = TempDir::new().unwrap();
+    /// let path = dir.path().join("foo");
+    /// let file = fs::OpenOptions::new()
+    ///     .create(true)
+    ///     .write(true)
+    ///     .open(&path)
+    ///     .unwrap();
+    /// let r = file.write_at(contents, 0).unwrap().await.unwrap();
+    /// assert_eq!(r, contents.len());
+    /// drop(file);
+    ///
+    /// let mut file = fs::File::open(path).unwrap();
+    /// assert_eq!(file.read_to_end(&mut rbuf).unwrap(), contents.len());
+    /// assert_eq!(&contents[..], &rbuf[..]);
+    /// # }
+    /// ```
+    fn write_at<'a>(
+        &'a self,
+        buf: &'a [u8],
+        offset: u64
+    ) -> io::Result<WriteAt<'a>>
+    {
+        let fd = self.as_fd();
+        let source = TokioSource(mio_aio::WriteAt::write_at(fd, offset, buf, 0));
+        Ok(TokioFileFut(Aio::new_for_aio(source)?))
+    }
+
+    /// Asynchronous equivalent of `pwritev`
+    ///
+    /// Similar to
+    /// [pwritev(2)](https://www.freebsd.org/cgi/man.cgi?query=write&sektion=2)
+    /// but asynchronous.  Writes a scatter-gather list of buffers into a
+    /// contiguous portion of a file.
+    ///
+    /// # Parameters
+    ///
+    /// - `bufs`:   The data to write.  A scatter-gather list of buffers.
+    /// - `offset`: Offset within the file at which to begin the write
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(x)`:  The operation was successfully created.  The future may be
+    ///             polled and will eventually return the final status of the
+    ///             operation.
+    /// - `Err(x)`: An error occurred before issueing the operation.  The result
+    ///             may be `drop`ped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::fs;
+    /// use std::io::{IoSlice, Read};
+    /// use tempfile::TempDir;
+    /// use tokio_file::AioFileExt;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// const EXPECT: &[u8] = b"abcdefghij";
+    /// let wbuf0 = b"abcdef";
+    /// let wbuf1 = b"ghij";
+    /// let wbufs = vec![IoSlice::new(wbuf0), IoSlice::new(wbuf1)];
+    /// let mut rbuf = Vec::new();
+    ///
+    /// let dir = TempDir::new().unwrap();
+    /// let path = dir.path().join("foo");
+    /// let file = fs::OpenOptions::new()
+    ///     .create(true)
+    ///     .write(true)
+    ///     .open(&path)
+    ///     .unwrap();
+    /// let r = file.writev_at(&wbufs[..], 0).unwrap().await.unwrap();
+    ///
+    /// assert_eq!(r, 10);
+    ///
+    /// let mut f = fs::File::open(path).unwrap();
+    /// let len = f.read_to_end(&mut rbuf).unwrap();
+    /// assert_eq!(len, EXPECT.len());
+    /// assert_eq!(rbuf, EXPECT);
+    /// # }
+    fn writev_at<'a>(&'a self, bufs: &[IoSlice<'a>], offset: u64)
+        -> io::Result<WritevAt<'a>>
+    {
+        let fd = self.as_fd();
+        let source = TokioSource(mio_aio::WritevAt::writev_at(fd, offset, bufs, 0));
+        Ok(TokioFileFut(Aio::new_for_aio(source)?))
+    }
+}
+
+impl<T: AsFd> AioFileExt for T {
+}
+
 /// Basically a Tokio file handle.  This is the starting point for tokio-file.
+#[deprecated(since = "0.10.0", note = "use AioFileExt instead")]
 #[derive(Debug)]
 pub struct File {
     file: fs::File,
@@ -109,6 +354,7 @@ pub struct File {
 
 // is_empty doesn't make much sense for files
 #[allow(clippy::len_without_is_empty)]
+#[allow(deprecated)]
 impl File {
     /// Get the file's size in bytes
     pub fn len(&self) -> io::Result<u64> {
@@ -118,7 +364,7 @@ impl File {
             // This ioctl is always safe
             unsafe {
                 diocgmediasize(self.file.as_raw_fd(), mediasize.as_mut_ptr())
-            }.map_err(|_| io::Error::from_raw_os_error(nix::errno::errno()))?;
+            }.map_err(|_| io::Error::from_raw_os_error(nix::errno::Errno::last_raw()))?;
             // Safe because we know the ioctl succeeded
             unsafe { Ok(mediasize.assume_init() as u64) }
         } else {
@@ -151,7 +397,7 @@ impl File {
     ///     .unwrap();
     /// # fs::remove_file("/tmp/tokio-file-new-example").unwrap();
     /// ```
-    pub fn new(file: fs::File) -> File {
+    pub fn new(file: fs::File) -> Self {
         let md = file.metadata().unwrap();
         let ft = md.file_type();
         let sectorsize = if ft.is_block_device() || ft.is_char_device() {
@@ -170,7 +416,9 @@ impl File {
         } else {
             1
         };
-        File {file, sectorsize}
+        File {file,
+        sectorsize
+        }
     }
 
     /// Open a new Tokio file with mode `O_RDWR | O_CREAT`.
@@ -219,10 +467,15 @@ impl File {
     /// assert_eq!(&rbuf[..], &EXPECT[..]);
     /// # })
     /// ```
-    pub fn read_at<'a>(&self, buf: &'a mut [u8], offset: u64)
+    pub fn read_at<'a, 'b>(&'b self, buf: &'a mut [u8], offset: u64)
         -> io::Result<ReadAt<'a>>
     {
-        let fd = self.file.as_raw_fd();
+        let fd: BorrowedFd<'_> = self.file.as_fd();
+        // Not really safe, but required for backwards-compatibility with
+        // tokio_file 0.9.0, which did not use I/O Safety
+        let fd: BorrowedFd<'static> = unsafe {
+            std::mem::transmute::<BorrowedFd<'b>, BorrowedFd<'static>>(fd)
+        };
         let source = TokioSource(mio_aio::ReadAt::read_at(fd, offset, buf, 0));
         Ok(TokioFileFut(Aio::new_for_aio(source)?))
     }
@@ -283,10 +536,15 @@ impl File {
     /// assert_eq!(&rbuf1[..], &EXPECT1[..]);
     /// # })
     /// ```
-    pub fn readv_at<'a>(&self, bufs: &'a mut [IoSliceMut<'a>],
+    pub fn readv_at<'a, 'b>(&'b self, bufs: &mut [IoSliceMut<'a>],
                         offset: u64) -> io::Result<ReadvAt<'a>>
     {
-        let fd = self.file.as_raw_fd();
+        let fd = self.file.as_fd();
+        // Not really safe, but required for backwards-compatibility with
+        // tokio_file 0.9.0, which did not use I/O Safety
+        let fd: BorrowedFd<'static> = unsafe {
+            std::mem::transmute::<BorrowedFd<'b>, BorrowedFd<'static>>(fd)
+        };
         let source = TokioSource(mio_aio::ReadvAt::readv_at(fd, offset, bufs, 0));
         Ok(TokioFileFut(Aio::new_for_aio(source)?))
     }
@@ -315,10 +573,14 @@ impl File {
     /// file.sync_all().unwrap().await.unwrap();
     /// # })
     /// ```
-    // TODO: add sync_all_data, for supported operating systems
-    pub fn sync_all(&self) -> io::Result<SyncAll> {
+    pub fn sync_all<'b>(&'b self) -> io::Result<SyncAll<'static>> {
         let mode = AioFsyncMode::O_SYNC;
-        let fd = self.file.as_raw_fd();
+        let fd = self.file.as_fd();
+        // Not really safe, but required for backwards-compatibility with
+        // tokio_file 0.9.0, which did not use I/O Safety
+        let fd: BorrowedFd<'static> = unsafe {
+            std::mem::transmute::<BorrowedFd<'b>, BorrowedFd<'static>>(fd)
+        };
         let source = TokioSource(mio_aio::Fsync::fsync(fd, mode, 0));
         Ok(TokioFileFut(Aio::new_for_aio(source)?))
     }
@@ -353,13 +615,18 @@ impl File {
     /// assert_eq!(&contents[..], &rbuf[..]);
     /// # })
     /// ```
-    pub fn write_at<'a>(
-        &self,
+    pub fn write_at<'a, 'b>(
+        &'b self,
         buf: &'a [u8],
         offset: u64
     ) -> io::Result<WriteAt<'a>>
     {
-        let fd = self.file.as_raw_fd();
+        let fd = self.file.as_fd();
+        // Not really safe, but required for backwards-compatibility with
+        // tokio_file 0.9.0, which did not use I/O Safety
+        let fd: BorrowedFd<'static> = unsafe {
+            std::mem::transmute::<BorrowedFd<'b>, BorrowedFd<'static>>(fd)
+        };
         let source = TokioSource(mio_aio::WriteAt::write_at(fd, offset, buf, 0));
         Ok(TokioFileFut(Aio::new_for_aio(source)?))
     }
@@ -416,15 +683,21 @@ impl File {
     /// assert_eq!(rbuf, EXPECT);
     /// # })
     /// ```
-    pub fn writev_at<'a>(&self, bufs: &[IoSlice<'a>], offset: u64)
+    pub fn writev_at<'a, 'b>(&'b self, bufs: &[IoSlice<'a>], offset: u64)
         -> io::Result<WritevAt<'a>>
     {
-        let fd = self.file.as_raw_fd();
+        let fd = self.file.as_fd();
+        // Not really safe, but required for backwards-compatibility with
+        // tokio_file 0.9.0, which did not use I/O Safety
+        let fd: BorrowedFd<'static> = unsafe {
+            std::mem::transmute::<BorrowedFd<'b>, BorrowedFd<'static>>(fd)
+        };
         let source = TokioSource(mio_aio::WritevAt::writev_at(fd, offset, bufs, 0));
         Ok(TokioFileFut(Aio::new_for_aio(source)?))
     }
 }
 
+#[allow(deprecated)]
 impl AsRawFd for File {
     fn as_raw_fd(&self) -> RawFd {
         self.file.as_raw_fd()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,4 +42,6 @@
 
 mod file;
 
-pub use file::{File, ReadAt, ReadvAt, SyncAll, WriteAt, WritevAt};
+pub use file::{AioFileExt, ReadAt, ReadvAt, SyncAll, WriteAt, WritevAt};
+#[allow(deprecated)]
+pub use file::File;

--- a/tests/aio_write_eagain.rs
+++ b/tests/aio_write_eagain.rs
@@ -1,14 +1,10 @@
-use std::io::ErrorKind;
+use std::{
+    fs::File,
+    io::ErrorKind
+};
 use futures::future;
 use tempfile::TempDir;
-use tokio_file::File;
-
-macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(e) => e,
-        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
-    })
-}
+use tokio_file::AioFileExt;
 
 // A write_at call fails with EAGAIN.  This test must run in its own process
 // since it intentionally uses all of the system's AIO resources.
@@ -21,9 +17,9 @@ async fn write_at_eagain() {
         panic!("sysctl: {:?}", limit);
     };
 
-    let dir = t!(TempDir::new());
+    let dir = TempDir::new().unwrap();
     let path = dir.path().join("write_at_eagain.0");
-    let file = t!(File::open(path));
+    let file = File::create(path).unwrap();
 
     let wbuf = vec![0u8; 4096];
 

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -5,7 +5,6 @@ use std::io::{IoSlice, IoSliceMut, Read, Write};
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
-use tokio_file::File;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -14,238 +13,403 @@ macro_rules! t {
     })
 }
 
-#[test]
-fn metadata() {
-    let wbuf = vec![0; 9000].into_boxed_slice();
-    let dir = t!(TempDir::new());
-    let path = dir.path().join("metadata");
-    let mut f = t!(fs::File::create(&path));
-    f.write_all(&wbuf).expect("write failed");
-    let file = t!(File::open(path));
-    let metadata = file.metadata().unwrap();
-    assert_eq!(9000, metadata.len());
-}
+mod aio_file_ext {
+    use tokio::fs::File;
+    use tokio_file::AioFileExt;
 
-#[test]
-fn len() {
-    let dir = t!(TempDir::new());
-    let path = dir.path().join("len");
-    let f = t!(fs::File::create(&path));
-    f.set_len(9000).unwrap();
-    let file = t!(File::open(path));
-    assert_eq!(9000, file.len().unwrap());
-}
+    use super::*;
 
-/// Demonstrate use of `tokio_file::File::new` with user-controlled options.
-/// It should fail because the file doesn't already exist and `O_CREAT` is not
-/// specified.
-#[test]
-fn new_nocreat() {
-    let dir = t!(TempDir::new());
-    let path = dir.path().join("nonexistent");
-    let r = fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(false)
-        .open(path)
-        .map(tokio_file::File::new);
-    assert!(r.is_err());
-}
-
-#[tokio::test]
-async fn read_at() {
-    const WBUF: &[u8] = b"abcdef";
-    const EXPECT: &[u8] = b"cdef";
-    let mut rbuf = [0; 4];
-    let off = 2;
-
-    let dir = t!(TempDir::new());
-    let path = dir.path().join("read_at");
-    let mut f = t!(fs::File::create(&path));
-    f.write_all(WBUF).expect("write failed");
-    let file = t!(File::open(&path));
-    let r = file.read_at(&mut rbuf[..], off)
-        .expect("read_at failed early").await
-        .unwrap();
-    assert_eq!(r, EXPECT.len());
-
-    assert_eq!(&rbuf[..], EXPECT);
-}
-
-#[tokio::test]
-async fn readv_at() {
-    const WBUF: &[u8] = b"abcdefghijklmnopqrwtuvwxyz";
-    const EXPECT0: &[u8] = b"cdef";
-    const EXPECT1: &[u8] = b"ghijklmn";
-    let mut rbuf0 = [0; 4];
-    let mut rbuf1 = [0; 8];
-    {
-        let mut rbufs = [IoSliceMut::new(&mut rbuf0[..]),
-            IoSliceMut::new(&mut rbuf1[..])];
+    #[tokio::test]
+    async fn read_at() {
+        const WBUF: &[u8] = b"abcdef";
+        const EXPECT: &[u8] = b"cdef";
+        let mut rbuf = [0; 4];
         let off = 2;
 
-        let dir = t!(TempDir::new());
-        let path = dir.path().join("readv_at");
-        let mut f = t!(fs::File::create(&path));
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("read_at");
+        let mut f = fs::File::create(&path).unwrap();
         f.write_all(WBUF).expect("write failed");
-        let file = t!(File::open(&path));
-        let r = file.readv_at(&mut rbufs[..], off)
-            .expect("readv_at failed early")
-            .await
+        let file = File::open(&path).await.unwrap();
+        let r = file.read_at(&mut rbuf[..], off)
+            .expect("read_at failed early").await
             .unwrap();
-        assert_eq!(12, r);
+        assert_eq!(r, EXPECT.len());
+
+        assert_eq!(&rbuf[..], EXPECT);
     }
 
-    assert_eq!(&rbuf0[..], EXPECT0);
-    assert_eq!(&rbuf1[..], EXPECT1);
-}
+    #[tokio::test]
+    async fn readv_at() {
+        const WBUF: &[u8] = b"abcdefghijklmnopqrwtuvwxyz";
+        const EXPECT0: &[u8] = b"cdef";
+        const EXPECT1: &[u8] = b"ghijklmn";
+        let mut rbuf0 = [0; 4];
+        let mut rbuf1 = [0; 8];
+        {
+            let mut rbufs = [IoSliceMut::new(&mut rbuf0[..]),
+                IoSliceMut::new(&mut rbuf1[..])];
+            let off = 2;
 
-#[tokio::test]
-async fn sync_all() {
-    const WBUF: &[u8] = b"abcdef";
+            let dir = TempDir::new().unwrap();
+            let path = dir.path().join("readv_at");
+            let mut f = fs::File::create(&path).unwrap();
+            f.write_all(WBUF).expect("write failed");
+            let file = File::open(&path).await.unwrap();
+            let r = file.readv_at(&mut rbufs[..], off)
+                .expect("readv_at failed early")
+                .await
+                .unwrap();
+            assert_eq!(12, r);
+        }
 
-    let dir = t!(TempDir::new());
-    let path = dir.path().join("sync_all");
-    let mut f = t!(fs::File::create(&path));
-    f.write_all(WBUF).expect("write failed");
-    let file = t!(File::open(&path));
-    file.sync_all()
-        .expect("sync_all failed early")
-        .await
-        .unwrap();
-}
+        assert_eq!(&rbuf0[..], EXPECT0);
+        assert_eq!(&rbuf1[..], EXPECT1);
+    }
 
-#[tokio::test]
-async fn write_at() {
-    let wbuf = b"abcdef";
-    let mut rbuf = Vec::new();
+    #[tokio::test]
+    async fn sync_all() {
+        const WBUF: &[u8] = b"abcdef";
 
-    let dir = t!(TempDir::new());
-    let path = dir.path().join("write_at");
-    let file = t!(File::open(&path));
-    let r = file.write_at(wbuf, 0)
-        .expect("write_at failed early")
-        .await
-        .unwrap();
-    assert_eq!(r, wbuf.len());
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("sync_all");
+        let mut f = fs::File::create(&path).unwrap();
+        f.write_all(WBUF).expect("write failed");
+        let file = File::open(&path).await.unwrap();
+        <File as AioFileExt>::sync_all(&file)
+            .expect("sync_all failed early")
+            .await
+            .unwrap();
+    }
 
-    let mut f = t!(fs::File::open(&path));
-    let len = t!(f.read_to_end(&mut rbuf));
-    assert_eq!(len, wbuf.len());
-    assert_eq!(&wbuf[..], &rbuf[..]);
-}
+    #[tokio::test]
+    async fn write_at() {
+        let wbuf = b"abcdef";
+        let mut rbuf = Vec::new();
 
-#[tokio::test]
-async fn writev_at() {
-    const EXPECT: &[u8] = b"abcdefghij";
-    let wbuf0 = b"abcdef";
-    let wbuf1 = b"ghij";
-    let wbufs = [IoSlice::new(&wbuf0[..]), IoSlice::new(&wbuf1[..])];
-    let mut rbuf = Vec::new();
-
-    let dir = t!(TempDir::new());
-    let path = dir.path().join("writev_at");
-    let file = t!(File::open(&path));
-    let r = file.writev_at(&wbufs[..], 0)
-        .expect("writev_at failed early")
-        .await
-        .unwrap();
-    assert_eq!(r, wbuf0.len() + wbuf1.len());
-
-    let mut f = t!(fs::File::open(&path));
-    let len = t!(f.read_to_end(&mut rbuf));
-    assert_eq!(len, EXPECT.len());
-    assert_eq!(rbuf, EXPECT);
-}
-
-#[tokio::test]
-async fn write_at_static() {
-    const WBUF: &[u8] = b"abcdef";
-    let mut rbuf = Vec::new();
-
-    let dir = t!(TempDir::new());
-    let path = dir.path().join("write_at");
-    {
-        let file = t!(File::open(&path));
-        let r = file.write_at(WBUF, 0)
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("write_at");
+        let file = File::create(&path).await.unwrap();
+        let r = file.write_at(wbuf, 0)
             .expect("write_at failed early")
             .await
             .unwrap();
-        assert_eq!(r, WBUF.len());
+        assert_eq!(r, wbuf.len());
+
+        let mut f = fs::File::open(&path).unwrap();
+        let len = f.read_to_end(&mut rbuf).unwrap();
+        assert_eq!(len, wbuf.len());
+        assert_eq!(&wbuf[..], &rbuf[..]);
     }
 
-    let mut f = t!(fs::File::open(&path));
-    let len = t!(f.read_to_end(&mut rbuf));
-    assert_eq!(len, WBUF.len());
-    assert_eq!(rbuf, WBUF);
+    #[tokio::test]
+    async fn write_at_static() {
+        const WBUF: &[u8] = b"abcdef";
+        let mut rbuf = Vec::new();
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("write_at");
+        {
+            let file = File::create(&path).await.unwrap();
+            let r = file.write_at(WBUF, 0)
+                .expect("write_at failed early")
+                .await
+                .unwrap();
+            assert_eq!(r, WBUF.len());
+        }
+
+        let mut f = fs::File::open(&path).unwrap();
+        let len = f.read_to_end(&mut rbuf).unwrap();
+        assert_eq!(len, WBUF.len());
+        assert_eq!(rbuf, WBUF);
+    }
+
+    #[tokio::test]
+    async fn writev_at() {
+        const EXPECT: &[u8] = b"abcdefghij";
+        let wbuf0 = b"abcdef";
+        let wbuf1 = b"ghij";
+        let wbufs = [IoSlice::new(&wbuf0[..]), IoSlice::new(&wbuf1[..])];
+        let mut rbuf = Vec::new();
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("writev_at");
+        let file = File::create(&path).await.unwrap();
+        let r = file.writev_at(&wbufs[..], 0)
+            .expect("writev_at failed early")
+            .await
+            .unwrap();
+        assert_eq!(r, wbuf0.len() + wbuf1.len());
+
+        let mut f = fs::File::open(&path).unwrap();
+        let len = f.read_to_end(&mut rbuf).unwrap();
+        assert_eq!(len, EXPECT.len());
+        assert_eq!(rbuf, EXPECT);
+    }
+
+    #[tokio::test]
+    async fn writev_at_static() {
+        const EXPECT: &[u8] = b"abcdefghi";
+        const WBUF0: &[u8] = b"abcdef";
+        const WBUF1: &[u8] = b"ghi";
+        let wbufs = [IoSlice::new(WBUF0), IoSlice::new(WBUF1)];
+        let mut rbuf = Vec::new();
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("writev_at_static");
+        let file = File::create(&path).await.unwrap();
+        let r = file.writev_at(&wbufs[..], 0)
+            .expect("writev_at failed early")
+            .await
+            .unwrap();
+        assert_eq!(r, WBUF0.len() + WBUF1.len());
+
+        let mut f = fs::File::open(&path).unwrap();
+        let len = f.read_to_end(&mut rbuf).unwrap();
+        assert_eq!(len, EXPECT.len());
+        assert_eq!(rbuf, EXPECT);
+    }
+
 }
 
-#[tokio::test]
-async fn writev_at_static() {
-    const EXPECT: &[u8] = b"abcdefghi";
-    const WBUF0: &[u8] = b"abcdef";
-    const WBUF1: &[u8] = b"ghi";
-    let wbufs = [IoSlice::new(WBUF0), IoSlice::new(WBUF1)];
-    let mut rbuf = Vec::new();
-
-    let dir = t!(TempDir::new());
-    let path = dir.path().join("writev_at_static");
-    let file = t!(File::open(&path));
-    let r = file.writev_at(&wbufs[..], 0)
-        .expect("writev_at failed early")
-        .await
-        .unwrap();
-    assert_eq!(r, WBUF0.len() + WBUF1.len());
-
-    let mut f = t!(fs::File::open(&path));
-    let len = t!(f.read_to_end(&mut rbuf));
-    assert_eq!(len, EXPECT.len());
-    assert_eq!(rbuf, EXPECT);
-}
-
-// Tests that work with device files
-mod dev {
+#[allow(deprecated)]
+mod file {
     use super::*;
+    use tokio_file::File;
 
-    use rstest::{fixture, rstest};
-    use std::os::unix::ffi::OsStrExt;
-    use std::path::PathBuf;
-
-    struct Md(PathBuf);
-    impl Drop for Md {
-        fn drop(&mut self) {
-            Command::new("mdconfig")
-                .args(["-d", "-u"])
-                .arg(&self.0)
-                .output()
-                .expect("failed to deallocate md(4) device");
-        }
+    #[test]
+    fn metadata() {
+        let wbuf = vec![0; 9000].into_boxed_slice();
+        let dir = t!(TempDir::new());
+        let path = dir.path().join("metadata");
+        let mut f = t!(fs::File::create(&path));
+        f.write_all(&wbuf).expect("write failed");
+        let file = t!(File::open(path));
+        let metadata = file.metadata().unwrap();
+        assert_eq!(9000, metadata.len());
     }
 
-    #[fixture]
-    fn md() -> Option<Md> {
-        if Uid::current().is_root() {
-            let output = Command::new("mdconfig")
-                .args(["-a", "-t",  "swap", "-s", "1m"])
-                .output()
-                .expect("failed to allocate md(4) device");
-            // Strip the trailing "\n"
-            let l = output.stdout.len() - 1;
-            let mddev = OsStr::from_bytes(&output.stdout[0..l]);
-            Some(Md(Path::new("/dev").join(mddev)))
-        } else {
-            None
-        }
+    #[test]
+    fn len() {
+        let dir = t!(TempDir::new());
+        let path = dir.path().join("len");
+        let f = t!(fs::File::create(&path));
+        f.set_len(9000).unwrap();
+        let file = t!(File::open(path));
+        assert_eq!(9000, file.len().unwrap());
     }
 
-    #[rstest]
-    fn len(md: Option<Md>){
-        if let Some(md) = md {
-            let file = t!(File::open(md.0.as_path()));
-            let len = file.len().unwrap();
-            assert_eq!(len, 1_048_576);
-        } else {
-            println!("This test requires root privileges");
+    /// Demonstrate use of `tokio_file::File::new` with user-controlled options.
+    /// It should fail because the file doesn't already exist and `O_CREAT` is not
+    /// specified.
+    #[test]
+    fn new_nocreat() {
+        let dir = t!(TempDir::new());
+        let path = dir.path().join("nonexistent");
+        let r = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(false)
+            .open(path)
+            .map(tokio_file::File::new);
+        assert!(r.is_err());
+    }
+
+    #[tokio::test]
+    async fn read_at() {
+        const WBUF: &[u8] = b"abcdef";
+        const EXPECT: &[u8] = b"cdef";
+        let mut rbuf = [0; 4];
+        let off = 2;
+
+        let dir = t!(TempDir::new());
+        let path = dir.path().join("read_at");
+        let mut f = t!(fs::File::create(&path));
+        f.write_all(WBUF).expect("write failed");
+        let file = t!(File::open(&path));
+        let r = file.read_at(&mut rbuf[..], off)
+            .expect("read_at failed early").await
+            .unwrap();
+        assert_eq!(r, EXPECT.len());
+
+        assert_eq!(&rbuf[..], EXPECT);
+    }
+
+    #[tokio::test]
+    async fn readv_at() {
+        const WBUF: &[u8] = b"abcdefghijklmnopqrwtuvwxyz";
+        const EXPECT0: &[u8] = b"cdef";
+        const EXPECT1: &[u8] = b"ghijklmn";
+        let mut rbuf0 = [0; 4];
+        let mut rbuf1 = [0; 8];
+        {
+            let mut rbufs = [IoSliceMut::new(&mut rbuf0[..]),
+                IoSliceMut::new(&mut rbuf1[..])];
+            let off = 2;
+
+            let dir = t!(TempDir::new());
+            let path = dir.path().join("readv_at");
+            let mut f = t!(fs::File::create(&path));
+            f.write_all(WBUF).expect("write failed");
+            let file = t!(File::open(&path));
+            let r = file.readv_at(&mut rbufs[..], off)
+                .expect("readv_at failed early")
+                .await
+                .unwrap();
+            assert_eq!(12, r);
+        }
+
+        assert_eq!(&rbuf0[..], EXPECT0);
+        assert_eq!(&rbuf1[..], EXPECT1);
+    }
+
+    #[tokio::test]
+    async fn sync_all() {
+        const WBUF: &[u8] = b"abcdef";
+
+        let dir = t!(TempDir::new());
+        let path = dir.path().join("sync_all");
+        let mut f = t!(fs::File::create(&path));
+        f.write_all(WBUF).expect("write failed");
+        let file = t!(File::open(&path));
+        file.sync_all()
+            .expect("sync_all failed early")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn write_at() {
+        let wbuf = b"abcdef";
+        let mut rbuf = Vec::new();
+
+        let dir = t!(TempDir::new());
+        let path = dir.path().join("write_at");
+        let file = t!(File::open(&path));
+        let r = file.write_at(wbuf, 0)
+            .expect("write_at failed early")
+            .await
+            .unwrap();
+        assert_eq!(r, wbuf.len());
+
+        let mut f = t!(fs::File::open(&path));
+        let len = t!(f.read_to_end(&mut rbuf));
+        assert_eq!(len, wbuf.len());
+        assert_eq!(&wbuf[..], &rbuf[..]);
+    }
+
+    #[tokio::test]
+    async fn writev_at() {
+        const EXPECT: &[u8] = b"abcdefghij";
+        let wbuf0 = b"abcdef";
+        let wbuf1 = b"ghij";
+        let wbufs = [IoSlice::new(&wbuf0[..]), IoSlice::new(&wbuf1[..])];
+        let mut rbuf = Vec::new();
+
+        let dir = t!(TempDir::new());
+        let path = dir.path().join("writev_at");
+        let file = t!(File::open(&path));
+        let r = file.writev_at(&wbufs[..], 0)
+            .expect("writev_at failed early")
+            .await
+            .unwrap();
+        assert_eq!(r, wbuf0.len() + wbuf1.len());
+
+        let mut f = t!(fs::File::open(&path));
+        let len = t!(f.read_to_end(&mut rbuf));
+        assert_eq!(len, EXPECT.len());
+        assert_eq!(rbuf, EXPECT);
+    }
+
+    #[tokio::test]
+    async fn write_at_static() {
+        const WBUF: &[u8] = b"abcdef";
+        let mut rbuf = Vec::new();
+
+        let dir = t!(TempDir::new());
+        let path = dir.path().join("write_at");
+        {
+            let file = t!(File::open(&path));
+            let r = file.write_at(WBUF, 0)
+                .expect("write_at failed early")
+                .await
+                .unwrap();
+            assert_eq!(r, WBUF.len());
+        }
+
+        let mut f = t!(fs::File::open(&path));
+        let len = t!(f.read_to_end(&mut rbuf));
+        assert_eq!(len, WBUF.len());
+        assert_eq!(rbuf, WBUF);
+    }
+
+    #[tokio::test]
+    async fn writev_at_static() {
+        const EXPECT: &[u8] = b"abcdefghi";
+        const WBUF0: &[u8] = b"abcdef";
+        const WBUF1: &[u8] = b"ghi";
+        let wbufs = [IoSlice::new(WBUF0), IoSlice::new(WBUF1)];
+        let mut rbuf = Vec::new();
+
+        let dir = t!(TempDir::new());
+        let path = dir.path().join("writev_at_static");
+        let file = t!(File::open(&path));
+        let r = file.writev_at(&wbufs[..], 0)
+            .expect("writev_at failed early")
+            .await
+            .unwrap();
+        assert_eq!(r, WBUF0.len() + WBUF1.len());
+
+        let mut f = t!(fs::File::open(&path));
+        let len = t!(f.read_to_end(&mut rbuf));
+        assert_eq!(len, EXPECT.len());
+        assert_eq!(rbuf, EXPECT);
+    }
+
+    // Tests that work with device files
+    mod dev {
+        use super::*;
+
+        use rstest::{fixture, rstest};
+        use std::os::unix::ffi::OsStrExt;
+        use std::path::PathBuf;
+
+        struct Md(PathBuf);
+        impl Drop for Md {
+            fn drop(&mut self) {
+                Command::new("mdconfig")
+                    .args(["-d", "-u"])
+                    .arg(&self.0)
+                    .output()
+                    .expect("failed to deallocate md(4) device");
+            }
+        }
+
+        #[fixture]
+        fn md() -> Option<Md> {
+            if Uid::current().is_root() {
+                let output = Command::new("mdconfig")
+                    .args(["-a", "-t",  "swap", "-s", "1m"])
+                    .output()
+                    .expect("failed to allocate md(4) device");
+                // Strip the trailing "\n"
+                let l = output.stdout.len() - 1;
+                let mddev = OsStr::from_bytes(&output.stdout[0..l]);
+                Some(Md(Path::new("/dev").join(mddev)))
+            } else {
+                None
+            }
+        }
+
+        #[rstest]
+        fn len(md: Option<Md>){
+            if let Some(md) = md {
+                let file = t!(File::open(md.0.as_path()));
+                let len = file.len().unwrap();
+                assert_eq!(len, 1_048_576);
+            } else {
+                println!("This test requires root privileges");
+            }
         }
     }
 }


### PR DESCRIPTION
Replace File with AioFileExt
    
This extension trait will slot into Tokio more nicely than the old File
struct.  It also uses I/O Safety.  The File struct is now deprecated,
and not updated with I/O Safety.
