### PR TITLE
Use 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-file"
-edition = "2018"
+edition = "2021"
 version = "0.10.0"
 authors = ["Alan Somers <asomers@gmail.com>"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
The new resolver removes a few features from dependencies.  For example, it removes the "user" feature from Nix.