### PR TITLE
Suppress the clippy::doc_overindent_list_items lint

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -1,4 +1,6 @@
 // vim: tw=80
+#![allow(clippy::doc_overindented_list_items)]
+
 use std::{
     fs,
     io::{self, IoSlice, IoSliceMut},


### PR DESCRIPTION
See also https://github.com/rust-lang/rust-clippy/discussions/14256