### PR TITLE
Raise MSRV to 1.71.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,7 @@ setup: &SETUP
 task:
   name: FreeBSD 13.5 MSRV
   env:
-    VERSION: 1.70.0
+    VERSION: 1.71.0
   << : *SETUP
   test_script:
     - . $HOME/.cargo/env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ### Changed
 
-- Updated mio to 1.0, and raised MSRV to 1.70.0
+- Updated mio to 1.0
   (#[58](https://github.com/asomers/tokio-file/pull/58))
+
+- Raised MSRV to 1.71.0
+  (#[59](https://github.com/asomers/tokio-file/pull/59))
 
 ## [0.10.0] - 2024-05-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Alan Somers <asomers@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/asomers/tokio-file"
-rust-version = "1.70"
+rust-version = "1.71"
 description = """
 Asynchronous file I/O for Tokio
 """


### PR DESCRIPTION
Because rust 1.70.0 frequently segfaults on FreeBSD 13.5.  I can't reproduce the problem with later compilers.