### PR TITLE
Update nix to 0.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased] - ReleaseDate
+
+### Changed
+
+- Use I/O Safety for the kqueue file descriptor.
+  (#[65](https://github.com/asomers/tokio-file/pull/65))
+
 ## [0.11.0] - 2025-04-19
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,18 @@ targets = [
 
 [dependencies]
 futures = "0.3.21"
-nix = { version = "0.29.0", default-features = false, features = ["ioctl"] }
-mio-aio = { version = "1", features = ["tokio"] }
-tokio = { version = "1.39.1", features = [ "net" ] }
+nix = { version = ">=0.30.0,<0.32.0", default-features = false, features = ["ioctl"] }
+mio-aio = { version = "2", features = ["tokio"] }
+tokio = { version = "1.52.0", features = [ "net" ] }
 
 [dev-dependencies]
 rstest = "0.18.0"
 getopts = "0.2.18"
 mdconfig = "0.2.0"
-nix = {version = "0.29.0", default-features = false, features = ["user"] }
+nix = {version = ">=0.30.0,<0.32.0", default-features = false, features = ["user"] }
 sysctl = "0.6"
 tempfile = "3.4"
-tokio = { version = "1.39.1", features = [ "fs", "io-util", "macros", "net", "rt", "rt-multi-thread" ] }
+tokio = { version = "1.52.0", features = [ "fs", "io-util", "macros", "net", "rt", "rt-multi-thread" ] }
 tokio-test = "0.4.4"
 
 [[test]]

--- a/src/file.rs
+++ b/src/file.rs
@@ -5,7 +5,7 @@
 
 use std::{
     io::{self, IoSlice, IoSliceMut},
-    os::unix::io::{AsFd, RawFd},
+    os::unix::io::{AsFd, BorrowedFd},
     pin::Pin,
 };
 
@@ -34,7 +34,7 @@ nix::ioctl_read! {
 struct TokioSource<T>(T);
 
 impl<T: mio_aio::SourceApi> AioSource for TokioSource<T> {
-    fn register(&mut self, kq: RawFd, token: usize) {
+    fn register_borrowed(&mut self, kq: BorrowedFd<'_>, token: usize) {
         self.0.register_raw(kq, token)
     }
 


### PR DESCRIPTION
Along with mio-aio and tokio.  They now use I/O safety for the kqueue.