### PR TITLE
ci: update FreeBSD workflow values to 15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           - freebsd_version: "14.4"
             rust_version: "stable"
-          - freebsd_version: "15.0"
+          - freebsd_version: "15.1"
             rust_version: "nightly"
     name: FreeBSD ${{ matrix.freebsd_version }} ${{ matrix.rust_version }}
     steps:
@@ -25,7 +25,7 @@ jobs:
       - name: Start VM
         uses: vmactions/freebsd-vm@v1
         with:
-          release: 15.1
+          release: ${{ matrix.freebsd_version }}
           usesh: true
       - name: Install dependencies
         shell: freebsd {0}
@@ -86,7 +86,7 @@ jobs:
       - name: Start VM
         uses: vmactions/freebsd-vm@v1
         with:
-          release: 15.1
+          release: ${{ matrix.freebsd_version }}
           usesh: true
       - name: Install dependencies
         shell: freebsd {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Start VM
         uses: vmactions/freebsd-vm@v1
         with:
-          release: ${{ matrix.freebsd_version }}
+          release: 15.1
           usesh: true
       - name: Install dependencies
         shell: freebsd {0}
@@ -86,7 +86,7 @@ jobs:
       - name: Start VM
         uses: vmactions/freebsd-vm@v1
         with:
-          release: ${{ matrix.freebsd_version }}
+          release: 15.1
           usesh: true
       - name: Install dependencies
         shell: freebsd {0}


### PR DESCRIPTION
Updates .github/workflows/ci.yml to use FreeBSD 15.1 for any `freebsd_version` or `release` values.